### PR TITLE
docs(readme): add brief HTTPS note for Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ It provides a comfortable web interface and backend written with flask to create
 
 It supports transformers model, and pytorch-dctts models
 
+
+### HTTPS Note
+
+The Flask web interface in this project is intended primarily for local use. If the application is exposed publicly, HTTPS is recommended to avoid transmitting data in plaintext.
+
+For small-scale or experimental deployments, a reverse proxy such as ngrok or a standard web server (for example, Nginx with TLS) can be used to provide HTTPS without modifying the application code.
+
+
 ## Live Demo (Finally Updated)
 Now you can experience the ancient technology from 5 years ago! Actually kind of amazing how GPT is capable of nowadays.
 


### PR DESCRIPTION
I’m an academic researcher conducting a study on the security of Flask-based AI applications. While reviewing this repository, I noticed that the Flask app appears to be deployed over HTTP without TLS. You definitely mention ngrok, but it’s my recommendation that it just be a little more clear to potential users how to secure API traffic and credentials when the app is accessed remotely.
I’ve submitted a small README update describing why HTTPS is important for deployed Flask apps, along with a couple simple options (ngrok or .Nginx) that enables HTTPS with minimal setup for small-scale or development use.
This is not intended as a criticism of the project, only as a practical security improvement suggestion.
Thank you for your great work!